### PR TITLE
Work on machine-readable grammar

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1655,7 +1655,7 @@ let+assign = inout
       'while' while-condition-list brace-stmt
 
     while-condition-list ::=
-      while-condition-item (',' while-condition)*
+      while-condition-item (',' while-condition-item)*
 
     while-condition-item ::=
       binding-decl

--- a/spec.md
+++ b/spec.md
@@ -1021,10 +1021,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       access-modifier? identifier generic-clause? conformance-list
 
     product-type-body ::=
-      '{' product-type-member-decl-list '}'
-
-    product-type-member-decl-list ::=
-      (product-type-member-decl | ';')*
+      '{' (product-type-member-decl | ';')* '}'
 
     product-type-member-decl ::=
       function-decl

--- a/spec.md
+++ b/spec.md
@@ -220,8 +220,8 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
     ```ebnf
     keyword ::= (one of)
       Any Never as as! _as!! async await break catch conformance continue deinit else extension
-      false for fun if import in infix init let match namespace nil postfix prefix private public
-      return sink static true try type typealias var where while yield
+      false for fun if import in infix init let match namespace nil postfix prefix public return
+      sink static true try type typealias var where while yield
     ```
 
 ### Identifiers

--- a/spec.md
+++ b/spec.md
@@ -1061,10 +1061,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       access-modifier? 'extension' type-expr where-clause?
 
     extension-body ::=
-      '{' extension-member-decl-list? '}'
-
-    extension-member-decl-list
-      extension-member-decl (';'* extension-member-decl)+ ';'*
+      '{' (extension-member-decl | ';')* '}'
 
     extension-member-decl ::=
       function-decl
@@ -1093,10 +1090,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       access-modifier? 'conformance' type-expr ':' conformance-list where-clause?
 
     conformance-body ::=
-      '{' conformance-member-decl-list? '}'
-
-    conformance-member-decl-list
-      conformance-member-decl (';'* conformance-member-decl)+ ';'*
+      '{' (conformance-member-decl | ';')* '}'
 
     conformance-member-decl ::=
       function-decl

--- a/spec.md
+++ b/spec.md
@@ -774,7 +774,10 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       generic-size-param
 
     generic-type-param ::=
-      identifier '...'? trait-annotation?
+      generic-type-param-identifier trait-annotation?
+
+    generic-type-param-identifier ::= (token)
+      identifier '...'?
 
     trait-annotation ::=
       ':' trait-composition

--- a/spec.md
+++ b/spec.md
@@ -841,7 +841,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       '{' (trait-requirement-decl | ';')* '}'
 
     trait-requirement-decl ::=
-      associated-type-decl
+      associated-decl
       function-decl
       subscript-decl
     ```
@@ -857,28 +857,35 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
 4. A trait declaration may only appear at global scope. It introduces __identifier__ as a name denoting the declared trait.
 
-5. The associated type, function, and subscript declarations that appear in the body of a trait specify the *requirements* of that trait. Such declarations may not have access levels. [Note: The access level of a requirement implementation depends on the visibility of the conformances requiring that implementation.]
+5. The associated type, associated size, function, and subscript declarations that appear in the body of a trait specify the *requirements* of that trait. Such declarations may not have access levels. [Note: The access level of a requirement implementation depends on the visibility of the conformances requiring that implementation.]
 
-### Associated type requirements
+### Associated type and size requirements
 
-1. An associated type declaration defines an *associated type requirement*. As associated type is a placeholder for a type that relates to the trait and must be specified by conforming types. Associated type declarations have the form:
+1. An associated type declaration defines an *associated type requirement*. An associated size declaration defines an *associated size requirement*. An associated type or size is a placeholder for a type or size that relates to the trait and must be specified by conforming types. Associated type and size declarations have the form:
 
     ```ebnf
+    associated-decl ::=
+      associated-type-decl
+      associated-size-decl
+
     associated-type-decl ::=
-      associated-type-head associated-type-constraints? associated-type-default?
+      associated-type-head associated-type-constraints? ('=' type-expr)?
 
     associated-type-head ::=
-      static-modifier? identifier
+      'type' identifier
 
     associated-type-constraints ::=
       conformance-list
       conformance-list? where-clause
 
-    associated-type-default ::=
-      '=' type-expr
+    associated-size-decl ::=
+      associated-size-head where-clause? ('=' expr)?
+
+    associated-size-head ::=
+      'size' identifier
     ```
 
-2. The type constraints of an associated type declaration impose constraints on the types that may satisfy an associated type requirement.
+2. The constraints of an associated type or size declaration impose constraints on the types that may satisfy an associated type or size requirement.
 
 3. (Example)
 

--- a/spec.md
+++ b/spec.md
@@ -1257,9 +1257,9 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       function-head function-signature function-body?
 
     function-head ::=
-      access-modifier? member-modifier* function-ident generic-clause? capture-list?
+      access-modifier? member-modifier* function-identifier generic-clause? capture-list?
 
-    function-ident ::=
+    function-identifier ::=
       'init'
       'deinit'
       'fun' identifier
@@ -1432,9 +1432,9 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       subscript-head subscript-signature subscript-body
 
     subscript-head ::=
-      member-modifier* subscript-ident? generic-clause? capture-list?
+      member-modifier* subscript-identifier? generic-clause? capture-list?
 
-    subscript-ident ::=
+    subscript-identifier ::=
       'subscript' identifier
       oper-notation 'subscript' operator
 

--- a/spec.md
+++ b/spec.md
@@ -1130,8 +1130,8 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
     binding-introducer ::= 
       'let'
       'var'
-      'sink let'
-      'sink var'
+      'sink' 'let'
+      'sink' 'var'
       'inout'
 
     binding-type-annotation ::=
@@ -1405,10 +1405,8 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
     method-impl ::=
       method-introducer brace-stmt?
 
-    method-introducer ::=
-      'let'
-      'sink'
-      'inout'
+    method-introducer ::= (one of)
+      let sink inout
     ```
 
 2. An explicit method implementation introduced with `let` is called a `let` method implementation; one introduced with `sink` is called a `sink` method implementation; one introduced with `inout` is called an `inout` method implementation.
@@ -1500,11 +1498,8 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
     subscript-impl ::=
       subscript-introducer brace-stmt?
 
-    subscript-introducer ::=
-      'let'
-      'sink'
-      'inout'
-      'assign'
+    subscript-introducer ::= (one of)
+      let sink inout assign
     ```
 
 2. Am explicit subscript implementation introduced with `let` is called a `let` subscript implementation; one introduced with `sink` is called a `sink` subscript implementation; one introduced with `inout` is called an `inout` subscript implementation; one introduced with `assign` is called an `assign` subscript implementation.
@@ -1840,10 +1835,10 @@ let+assign = inout
 
     ```ebnf
     scalar-literal ::=
-      BOOL-LITERAL
-      INT-LITERAL
-      FLOAT-LITERAL
-      STRING-LITERAL
+      boolean-literal
+      integer-literal
+      floating-point-literal
+      string-literal
     ```
 
 ### Compound literals
@@ -2042,10 +2037,8 @@ let+assign = inout
 1. Operator notations have the form:
 
     ```ebnf
-    oper-notation ::=
-      'infix'
-      'prefix'
-      'postfix'
+    oper-notation ::= (one of)
+      infix prefix postfix
     ```
 
 # Type expressions

--- a/spec.md
+++ b/spec.md
@@ -1749,6 +1749,7 @@ let+assign = inout
 
     ```ebnf
     jump-stmt ::=
+      cond-binding-stmt
       'return' expr?
       'yield' expr
       'break'
@@ -1756,6 +1757,21 @@ let+assign = inout
     ```
 
 2. `break` and `continue` statements are called loop jump statements. A loop jump statement applies to the innermost loop.
+
+### Conditional binding statements
+
+1. Conditional binding statements have the form:
+
+    ```ebnf
+    cond-binding-stmt ::=
+      binding-head binding-type-annotation? '??' cond-binding-body
+
+    cond-binding-body ::=
+      jump-stmt
+      expr
+    ```
+
+2. If the body of a conditional binding statement is an expression, it must have type `Never`.
 
 ### Return statements
 

--- a/spec.md
+++ b/spec.md
@@ -767,22 +767,22 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
     ```ebnf
     generic-clause ::=
-      '<' generic-param (',' generic-param)* where-clause? '>'
+      '<' generic-parameter (',' generic-parameter)* where-clause? '>'
 
-    generic-param ::=
-      generic-type-param
-      generic-size-param
+    generic-parameter ::=
+      generic-type-parameter
+      generic-size-parameter
 
-    generic-type-param ::=
-      generic-type-param-identifier trait-annotation?
+    generic-type-parameter ::=
+      generic-type-parameter-identifier trait-annotation?
 
-    generic-type-param-identifier ::= (token)
+    generic-type-parameter-identifier ::= (token)
       identifier '...'?
 
     trait-annotation ::=
       ':' trait-composition
 
-    generic-size-param ::=
+    generic-size-parameter ::=
       identifier ':' 'size'
     ```
 
@@ -1319,7 +1319,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
     ```ebnf
     function-signature ::=
-      '(' param-list? ')' ('->' type-expr)?
+      '(' parameter-list? ')' ('->' type-expr)?
     ```
 
 2. The default value of a parameter declaration may not refer to another parameter in a function signature.
@@ -1487,10 +1487,10 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
     ```ebnf
     subscript-signature ::=
-      explicit-subscript-param-list? ':' 'var'? type-expr
+      explicit-subscript-parameter-list? ':' 'var'? type-expr
 
-    explicit-subscript-param-list ::=
-      '(' param-list? ')'
+    explicit-subscript-parameter-list ::=
+      '(' parameter-list? ')'
     ```
 
 2. The default value of a parameter declaration may not refer to another parameter in a subscript signature.
@@ -1535,11 +1535,11 @@ let+assign = inout
 1. Parameter declarations have the form:
 
     ```ebnf
-    param-list ::=
-      param-decl (',' param-decl)?
+    parameter-list ::=
+      parameter-decl (',' parameter-decl)?
 
-    param-decl ::=
-      (identifier | '_') identifier? (':' param-type-expr)? default-value?
+    parameter-decl ::=
+      (identifier | '_') identifier? (':' parameter-type-expr)? default-value?
 
     default-value ::=
       '=' expr

--- a/spec.md
+++ b/spec.md
@@ -52,9 +52,8 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 1. The Boolean literals are `true` and `false`:
 
     ```ebnf
-    boolean-literal ::=
-      true
-      false
+    boolean-literal ::= (one of)
+      true false
     ```
 
 #### Integer literals
@@ -68,30 +67,29 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       decimal-literal
       hexadecimal-literal
 
-    binary-literal ::= '0b' ('0' | '1' | '_')+
+    binary-digit ::= (one of)
+      0 1 _
 
-    octal-literal ::=
-      0o octal-digit
-      0o _
-      octal-literal octal-digit
-      octal-literal _
+    binary-literal ::= (token)
+      '0b' binary-digit+
 
     octal-digit ::= (one of)
-      0 1 2 3 4 5 6 7
+      0 1 2 3 4 5 6 7 _
 
-    decimal-literal ::=
-      decimal-digit
-      decimal-literal decimal-digit
-      decimal-literal _
+    octal-literal ::= (token)
+      '0o' octal-digit+
 
-    hexadecimal-literal
-      0x hexadecimal-digit
-      0x _
-      hexadecimal-literal hexadecimal-digit
-      hexadecimal-literal _
+    decimal-digit ::= (one of)
+      0 1 2 3 4 5 6 7 8 9 _
+
+    decimal-literal ::= (token)
+      decimal-digit+
 
     hexadecimal-digit ::= (one of)
-      0 1 2 3 4 5 6 7 8 9 a A b B c C d D e E f F
+      0 1 2 3 4 5 6 7 8 9 A B C D E F a b c d e f _
+
+    hexadecimal-literal ::= (token)
+      '0x' hexadecimal-digit+
     ```
 
 2. The sequence of digits of a literal are interpreted as follows, ignoring all occurrences of `_`:
@@ -119,27 +117,27 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       decimal-floating-point-literal
       hexadecimal-floating-point-literal
 
-    decimal-floating-point-literal ::=
+    decimal-floating-point-literal ::= (token)
       decimal-fractional-constant exponent?
       decimal-literal exponent
 
-    decimal-fractional-constant ::=
+    decimal-fractional-constant ::= (token)
       decimal-literal . decimal-literal
 
-    exponent ::=
-      e exponent-sign? decimal-literal
-      E exponent-sign? decimal-literal
+    exponent := (token)
+      'e' exponent-sign? decimal-literal
+      'E' exponent-sign? decimal-literal
 
-    hexadecimal-floating-point-literal ::=
-      hexadecimal-fractional-constant binary-exponent
+    hexadecimal-floating-point-literal ::= (token)
+      hexadecimal-fractional-constant binary-exponent?
       hexadecimal-literal binary-exponent
 
-    hexadecimal-fractional-constant ::=
-      hexadecimal-literal . hexadecimal-literal
+    hexadecimal-fractional-constant ::= (token)
+      hexadecimal-literal '.' hexadecimal-literal
 
-    binary-exponent ::=
-      p exponent-sign? decimal-literal
-      P exponent-sign? decimal-literal
+    binary-exponent := (token)
+      'p' exponent-sign? decimal-literal
+      'P' exponent-sign? decimal-literal
 
     exponent-sign ::= (one of)
       + -
@@ -149,14 +147,14 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
 3. The default inferred type of an integer literal is the Val standard library `Double`, which represents a 64-bit floating point number. If the interpreted value of a floating-point literal is not in the range of representable values for its type, the program is ill-formed. Otherwise, the value of a floating-point literal is the interpreted value if representable, else the larger or smaller representable value nearest the interpreted value, chosen in an implementation-defined manner.
 
-#### Character literals
+#### Unicode scalar literals
 
-1. Character literals have the form:
+1. Unicode scalar literals have the form:
 
     ```ebnf
-    character-literal ::=
-      ' escape-char '
-      ' c-char '
+    unicode-scalar-literal ::= (token)
+      single-quote escape-char single-quote
+      single-quote c-char single-quote
 
     escape-char ::=
       simple-escape
@@ -165,10 +163,14 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
     simple-escape ::= (one of)
       \0 \t \n \r \' \"
 
-    unicode-escape ::=
-      \u hexadecimal-digit
+    single-quote ::= (one of)
+      '
 
-    c-char ::= (any Unicode character except ')
+    unicode-escape ::= (token)
+      '\u' hexadecimal-digit+
+
+    c-char ::= (regexp)
+      [^']
     ```
 
 2. The __hexadecimal-digit__  of a __unicode-escape__ represents a Unicode scalar value.
@@ -183,7 +185,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       multiline-string
 
     simple-string ::=
-      " simple-quoted-text? "
+      '"' simple-quoted-text? '"'
 
     simple-quoted-text ::=
       simple-quoted-text-item

--- a/spec.md
+++ b/spec.md
@@ -300,7 +300,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
 6. (Example)
 
-    ```ebnf
+    ```val
     type A {
       fun foo() {}
     }
@@ -313,7 +313,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
 7. A declaration may introduce one or more names in the declaration space of the innermost lexical scope that contains it. The same name may not be introduced more than once in a declaration space.
 
-    ```ebnf
+    ```val
     type A {
       fun foo() {}
     }

--- a/spec.md
+++ b/spec.md
@@ -184,10 +184,10 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       simple-string
       multiline-string
 
-    simple-string ::=
+    simple-string ::= (token)
       '"' simple-quoted-text? '"'
 
-    simple-quoted-text ::=
+    simple-quoted-text ::= (token)
       simple-quoted-text-item
       simple-quoted-text simple-quoted-text-item
 
@@ -195,12 +195,13 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       escape-char
       s-char
 
-    s-char ::= (any character except ", U+A, and U+D)
-
-    multiline-string ::=
+    s-char ::= (regexp)
+      [^"\x0a\x0d]
+      
+    multiline-string ::= (token)
       """ multiline-quoted-text """
 
-    multiline-quoted-text ::=
+    multiline-quoted-text ::= (token)
       multiline-quoted-text-item
       multiline-quoted-text multiline-quoted-text-item
 
@@ -208,7 +209,8 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       escape-char
       m-char
 
-    m-char ::= (any character except " leading a sequence of 3 or more contiguous ")
+    m-char ::= (regexp)
+      [^"]|"(?!"")
     ```
 
 2. The first new-line delimiter in a multiline string literal is not part of the value of that literal if it immediately succeeds the opening delimiter. The last new-line delimiter that is succeeded by a contiguous sequence of inline spaces followed by the closing delimiter is called the indentation marker. The indentation marker and the succeeding inline spaces specify the indentation pattern of the literal and are not part of its value. The pattern is defined as the sequence of inline spaces between the indentation marker and the closing delimiter. That sequence must be homogeneous. If the literal has no indentation marker, its indentation pattern is an empty sequence. Each line of a multiline string literal must begin with the indentation pattern of that literal. That prefix is not part of the value of the literal.

--- a/spec.md
+++ b/spec.md
@@ -841,7 +841,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
 2. Trait declarations have the form:
 
-    ```val
+    ```ebnf
     trait-decl ::=
       trait-head trait-body
 

--- a/spec.md
+++ b/spec.md
@@ -711,7 +711,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
     ```ebnf
     access-modifier ::=
-      public
+      'public'
     ```
 
 2. A declaration is *private* if it does not have any access modifier. A private declaration *exposes* the names that it introduces to the innermost scope that contains it. The static and non-static members introduced in the lexical scope of a type declaration are additionally exposed to the lexical scopes of the conformance declarations of the declared type.
@@ -749,10 +749,8 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       receiver-modifier
       static-modifier
 
-    receiver-modifier ::=
-      'sink'
-      'inout'
-      'out'
+    receiver-modifier ::= (one of)
+      sink inout out
 
     static-modifier ::=
       'static'
@@ -772,7 +770,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
     ```ebnf
     conformance-list ::=
-      ':' type-identifier (',' type-identifier)
+      ':' type-identifier (',' type-identifier)*
     ```
 
 ## Generic clauses
@@ -849,13 +847,13 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       access-modifier? 'trait' identifier trait-refinement-list
 
     trait-refinement-list ::=
-      ':' type-name (',' type-name)
+      ':' type-name (',' type-name)*
 
     trait-body ::=
-      '{' trait-requirement-decl-list? '}'
+      '{' trait-requirement-decl-list '}'
 
     trait-requirement-decl-list ::=
-      trait-requirement-decl (';'* trait-requirement-decl)+ ';'*
+      (trait-requirement-decl | ';')*
 
     trait-requirement-decl ::=
       associated-type-decl
@@ -1031,10 +1029,10 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       access-modifier? identifier generic-clause? conformance-list
 
     product-type-body ::=
-      '{' product-type-member-decl-list? '}'
+      '{' product-type-member-decl-list '}'
 
-    product-type-member-decl-list
-      product-type-member-decl (';'* product-type-member-decl)+ ';'*
+    product-type-member-decl-list ::=
+      (product-type-member-decl | ';')*
 
     product-type-member-decl ::=
       function-decl

--- a/spec.md
+++ b/spec.md
@@ -1259,7 +1259,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       'init'
       'deinit'
       'fun' identifier
-      oper-notation 'fun' OPER
+      oper-notation 'fun' operator
 
     function-body ::=
       function-bundle-body
@@ -1267,6 +1267,9 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
     function-bundle-body ::=
       '{' method-impl+ '}'
+
+    operator ::= (token)
+      raw-operator+
     ```
 
 2. (Example)
@@ -1431,7 +1434,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
     subscript-ident ::=
       'subscript' identifier
-      oper-notation 'subscript' OPER
+      oper-notation 'subscript' operator
 
     subscript-body ::=
       brace-stmt
@@ -1931,7 +1934,7 @@ let+assign = inout
     entity-ident ::=
       identifier
       function-entity-ident
-      oper-notation OPER
+      oper-notation operator
 
     function-entity-ident ::=
       identifier '(' argument-label+ ')'

--- a/spec.md
+++ b/spec.md
@@ -270,7 +270,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
 3. (Example) `foo` and `+` are bare names. `foo(bar:ham:)` is a function name. `infix+` is an operator name. `foo.let` and `foo(bar:ham:).let`. are method names.
 
-4. An __ident-expr__ is said to be a *use* of the name that it denotes. An expression is said to be a use of the all the uses of its sub-expressions.
+4. An __identifier-expr__ is said to be a *use* of the name that it denotes. An expression is said to be a use of the all the uses of its sub-expressions.
 
 5. A *binding* is a name that denotes an object or a projection. The value of a binding is the denoted object or the value of the denoted projection. The value of a binding may be mutable or immutable. A mutable binding can modify its value; an immutable binding cannot. A binding is *dead* at a given program point if it denotes an object that has been consumed. A mutable binding can be *resurrected* by consuming an object; an immutable binding cannot.
 
@@ -1263,7 +1263,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       'init'
       'deinit'
       'fun' identifier
-      oper-notation 'fun' operator
+      operator-notation 'fun' operator
 
     function-body ::=
       function-bundle-body
@@ -1436,7 +1436,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
     subscript-identifier ::=
       'subscript' identifier
-      oper-notation 'subscript' operator
+      operator-notation 'subscript' operator
 
     subscript-body ::=
       brace-stmt
@@ -1935,7 +1935,7 @@ let+assign = inout
 
     ```ebnf
     primary-decl-ref ::=
-      ident-expr type-argument-list?
+      identifier-expr type-argument-list?
     ```
 
 ### Identifiers
@@ -1943,21 +1943,24 @@ let+assign = inout
 1. Identifiers have the form:
 
     ```ebnf
-    ident-expr ::=
-      entity-ident impl-ident?
+    identifier-expr ::=
+      entity-identifier impl-identifier?
 
-    entity-ident ::=
+    entity-identifier ::=
       identifier
-      function-entity-ident
-      oper-notation operator
+      function-entity-identifier
+      operator-entity-identifier
 
-    function-entity-ident ::=
+    function-entity-identifier ::= (token)
       identifier '(' argument-label+ ')'
 
-    argument-label ::=
+    operator-entity-identifier ::= (token)
+      operator-notation operator
+
+    argument-label ::= (token)
       (identifier | '_') ':'
 
-    impl-ident ::=
+    impl-identifier ::= (token)
       '.' method-introducer
     ```
 
@@ -2057,7 +2060,7 @@ let+assign = inout
 1. Operator notations have the form:
 
     ```ebnf
-    oper-notation ::= (one of)
+    operator-notation ::= (one of)
       infix prefix postfix
     ```
 

--- a/spec.md
+++ b/spec.md
@@ -241,22 +241,20 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 1. Identifiers are case-sensitive sequences of letters and digits. They have the form:
 
     ```ebnf
-    identifier ::=
-      identifier-head
-      identifier identifier-tail
-      backquoted-identifier
+    identifier ::= (token)
+      identifier-head identifier-tail*
+      '`' bq-char+ '`'
       contextual-keyword
 
-    identifier-head ::= (_ and any character in categories Lu, Ll, Lt, Lm, Lo, Nl)
+    identifier-head ::= (regexp)
+      [_\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}]
 
-    identifier-tail ::= (any character in categories Lu, Ll, Lt, Lm, Lo, Mn, Mc, Nl, Nd, Pc)
-
-    backquoted-identifier ::=
-      backquoted-identifier-head bq-char `
-      backquoted-identifier bq-char `
-
-    bq-char ::= (any character except `, U+A, and U+D)
-
+    identifier-tail ::= (regexp)
+      [\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Mn}\p{Mc}\p{Nl}\p{Nd}\p{Pc}]
+    
+    bq-char ::= (regexp)
+      [^`\x0a\x0d]
+      
     contextual-keyword ::= (one of)
       mutating size any
     ```
@@ -268,7 +266,8 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 1. Raw operators have the form:
 
     ```ebnf
-    raw-operator ::= (-, *, /, ^, %, &, ! ?, and any character in category Sm)
+    raw-operator ::= (regexp)
+      [-*/^%&!?\p{Sm}]
     ```
 
     [Note: The Unicode category Sm includes +, =, <, >, |, and ~.]

--- a/spec.md
+++ b/spec.md
@@ -1602,7 +1602,7 @@ let+assign = inout
 
 4. Control enters the lexical scope of a brace statement before executing any sub-statements and exits that lexical scope when it reaches the end of the brace statement.
 
-## Loop statments
+## Loop statements
 
 ### General
 
@@ -1621,7 +1621,7 @@ let+assign = inout
 
 4. A continuation test is a procedure that determines whether an additional iteration should take place, or whether control should exit the loop. A continuation test may take in the head or in the body of a loop.
 
-### Do-while statments
+### Do-while statements
 
 1. `do-while` statements have the form:
 
@@ -1646,7 +1646,7 @@ let+assign = inout
 
 4. The head of a `do-while` statement unconditionally transfers control to the body of the loop. The tail performs a continuation test. If it succeeds, control is transferred back to the head. Otherwise, it exits the loop.
 
-### While statments
+### While statements
 
 1. `while` statements have the form:
 
@@ -1757,13 +1757,13 @@ let+assign = inout
 
 2. `break` and `continue` statements are called loop jump statements. A loop jump statement applies to the innermost loop.
 
-### Return statments
+### Return statements
 
 1. Return statements return an object from a function, terminating the execution path and transferring control back to the function's caller.
 
 2.  The expression in a return statement is called its operand. If the operand is omitted, it is interpreted as `()`. A return statement consumes the value of the operand to initialize an escapable object as result of the call to the containing function.
 
-### Yield statments
+### Yield statements
 
 1. Yield statements project an object out of a subscript, suspending the execution path and temporarily transferring control to the subscript's caller. Control comes back to the subscript once after the last use of the yielded projection at the call site, resuming execution at the statement that directly follows the yield statement.
 

--- a/spec.md
+++ b/spec.md
@@ -1127,7 +1127,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
     binding-head ::=
       access-modifier? member-modifier* binding-introducer pattern
 
-    binding-introducer ::=
+    binding-introducer ::= 
       'let'
       'var'
       'sink let'
@@ -1249,7 +1249,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
 
     ```ebnf
     function-decl ::=
-      'default init'
+      'default' 'init'
       function-head function-signature function-body?
 
     function-head ::=
@@ -1258,7 +1258,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
     function-ident ::=
       'init'
       'deinit'
-      'fun' IDENT
+      'fun' identifier
       oper-notation 'fun' OPER
 
     function-body ::=
@@ -1430,7 +1430,7 @@ On a theoretical front, Val owes greatly to linear types [(Wadler 1990)](https:/
       member-modifier* subscript-ident? generic-clause? capture-list?
 
     subscript-ident ::=
-      'subscript' IDENT
+      'subscript' identifier
       oper-notation 'subscript' OPER
 
     subscript-body ::=
@@ -1534,7 +1534,7 @@ let+assign = inout
       param-decl (',' param-decl)?
 
     param-decl ::=
-      (IDENT | '_') IDENT? (':' param-type-expr)? default-value?
+      (identifier | '_') identifier? (':' param-type-expr)? default-value?
 
     default-value ::=
       '=' expr
@@ -1929,15 +1929,15 @@ let+assign = inout
       entity-ident impl-ident?
 
     entity-ident ::=
-      IDENT
+      identifier
       function-entity-ident
       oper-notation OPER
 
     function-entity-ident ::=
-      IDENT '(' argument-label+ ')'
+      identifier '(' argument-label+ ')'
 
     argument-label ::=
-      (IDENT | '_') ':'
+      (identifier | '_') ':'
 
     impl-ident ::=
       '.' method-introducer
@@ -2015,7 +2015,7 @@ let+assign = inout
       call-argument ( ',' call-argument )*
 
     call-argument :=
-      (IDENT ':')? expr
+      (identifier ':')? expr
     ```
 
     The opening parenthesis preceding the call argument list must be on the same line as the callee.


### PR DESCRIPTION
I'm trying to make the minimal changes needed to make the grammar something I could parse mechanically and use to generate a parser.  I think regexps may be unavoidable in order to usefully represent things like “any unicode character except `'`” (and several of the more complex character classes), and if used more liberally at the token level could even result in a more readable spec.

So far the conventions are:
- `lhs ::= (token) …`: each RHS line is an alternative; literal strings are single-quoted and no spaces are allowed between recognized elements
- `lhs ::= (one of) …`: the RHS is a whitespace-separated list of literal text alternatives
- `lhs ::= (regexp) …`: each RHS line (after stripping leading/trailing whitespace) is an alternative interpreted as an ICU-conformant regular expression
- `lhs ::= …` (no parenthesized note): each RHS line is an alternative; literal strings are single-quoted, and arbitrary whitespace is accepted between recognized elements

Your thoughts appreciated.