### PR TITLE
Add access-modifier to memberwise-init-decl

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1303,7 +1303,7 @@ Hylo is a language based on the principles of mutable value semantics (MVS) (Rac
       function-head function-signature function-body?
 
     memberwise-init-decl ::=
-      'memberwise' 'init'
+      access-modifier? 'memberwise' 'init'
 
     deinit-decl ::=
       'deinit' brace-stmt


### PR DESCRIPTION
`public memberwise init` shows up and seems to be allowed.